### PR TITLE
Update QueryBuilder.php

### DIFF
--- a/src/Classes/QueryBuilder.php
+++ b/src/Classes/QueryBuilder.php
@@ -132,7 +132,8 @@ class QueryBuilder implements QueryBuilderContract
             $columnKeys = array_keys($this->localColumns);
 
             foreach ($columnKeys as $index => $key) {
-                $columnKeys[$index] = $this->model->getTable().".$key";
+                $as = isset($this->localColumns[$key]['as']) ? ' as ' . $this->localColumns[$key]['as'] : '';
+                $columnKeys[$index] = $this->model->getTable().".$key" . $as;
             }
 
             return $columnKeys;


### PR DESCRIPTION
Wanted to help. This helps you alias a column. Fixes an request. 
Usage:
    protected $dataTableColumns = [
        'id' => [
            'searchable' => false,
            'orderable' => true,
            'as' => 'user_id'
        ],